### PR TITLE
Fixed  Permissions again /etc/SystemHostsBlocker/(*) should we owned by root:wheel and not executable...

### DIFF
--- a/iOS/DEBIAN/postinst
+++ b/iOS/DEBIAN/postinst
@@ -3,7 +3,7 @@
 echo "Overwriting old hosts file..."
 cp -a /etc/SystemHostsBlocker/systemhosts /etc/hosts
 echo "Fixing permissions..."
-chmod 644 /etc/hosts /etc/SystemHostsBlocker/ /etc/SystemHostsBlocker/defaulthosts /etc/SystemHostsBlocker/systemhosts
+chmod 644 /etc/hosts /etc/SystemHostsBlocker/defaulthosts /etc/SystemHostsBlocker/systemhosts
 chown root:wheel /etc/hosts /etc/SystemHostsBlocker/ /etc/SystemHostsBlocker/defaulthosts /etc/SystemHostsBlocker/systemhosts
 echo "Killing discoveryd/mDNSResponder..."
 killall -9 discoveryd

--- a/iOS/DEBIAN/postinst
+++ b/iOS/DEBIAN/postinst
@@ -3,8 +3,8 @@
 echo "Overwriting old hosts file..."
 cp -a /etc/SystemHostsBlocker/systemhosts /etc/hosts
 echo "Fixing permissions..."
-chmod 644 /etc/hosts
-chown root:wheel /etc/hosts
+chmod 644 /etc/hosts /etc/SystemHostsBlocker/ /etc/SystemHostsBlocker/defaulthosts /etc/SystemHostsBlocker/systemhosts
+chown root:wheel /etc/hosts /etc/SystemHostsBlocker/ /etc/SystemHostsBlocker/defaulthosts /etc/SystemHostsBlocker/systemhosts
 echo "Killing discoveryd/mDNSResponder..."
 killall -9 discoveryd
 killall -9 mDNSResponder


### PR DESCRIPTION
Since defaulthosts and systemhosts are executable and owned by mobile:staff I have fixed it. Hopefully it works like this. Could you please try removing the HostsBlocker too. Hope that it works. I can't test it for now. 
Ah: discoveryd is not running on my device (iOS 10.2) maybe it's not called like this?